### PR TITLE
Fix readme list line breaks for GitHub.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A plugin for artillery.io that records response data into cloudwatch.
 
 To use:
+
 1. `npm install -g artillery`
 2. `npm install artillery-plugin-cloudwatch` (add `-g` if you like)
 3. Add `cloudwatch` plugin config to your "`hello.json`" Artillery script


### PR DESCRIPTION
Readme on GitHub does not always match what we see in the editors. Having an empty line before the numbered list is required if you want to prevent the list from being shown inline.