### PR TITLE
Improve CW metrics and make it match InfluxDB plugin

### DIFF
--- a/lib/cloudwatch.js
+++ b/lib/cloudwatch.js
@@ -13,6 +13,7 @@ var aws = require('aws-sdk'),
         PARAM_MUST_BE_STRING: '" param must have a string value',
         PARAM_MUST_HAVE_LENGTH_OF_AT_LEAST_ONE: '" param must have a length of at least one',
         PARAM_MUST_BE_ARRAY: '" param must have an array value',
+        MAX_METRIC_DATA_SIZE: 20,
         // Report Array Positions
         TIMESTAMP: 0,
         REQUEST_ID: 1,
@@ -197,13 +198,13 @@ var aws = require('aws-sdk'),
 
             self.baseDimensions = [{
                 Name: 'TEST_NAME',
-                Value: self.config[constants.PLUGIN_TEST_NAME]
+                Value: self.config[constants.PLUGIN_PARAM_TEST_NAME]
             }];
           
-            if (self.config[constants.PLUGIN_ENVIRONMENT]) {
+            if (self.config[constants.PLUGIN_PARAM_ENVIRONMENT]) {
                 self.baseDimensions.push({
                     Name: 'ENVIRONMENT',
-                    Value: self.config[constants.PLUGIN_ENVIRONMENT]
+                    Value: self.config[constants.PLUGIN_PARAM_ENVIRONMENT]
                 });
             }
             

--- a/lib/cloudwatch.js
+++ b/lib/cloudwatch.js
@@ -5,7 +5,8 @@ var aws = require('aws-sdk'),
     constants = {
         PLUGIN_NAME: 'cloudwatch',
         PLUGIN_PARAM_NAMESPACE: 'namespace',
-        // PLUGIN_PARAM_METRICS: 'metrics',
+        PLUGIN_PARAM_TEST_NAME: 'testName',
+        PLUGIN_PARAM_ENVIRONMENT: 'environment',
         THE: 'The "',
         CONFIG_REQUIRED: '" plugin requires configuration under <script>.config.plugins.',
         PARAM_REQUIRED: '" parameter is required',
@@ -22,9 +23,12 @@ var aws = require('aws-sdk'),
         pluginConfigRequired: constants.THE + constants.PLUGIN_NAME + constants.CONFIG_REQUIRED + constants.PLUGIN_NAME,
         pluginParamNamespaceRequired: constants.THE + constants.PLUGIN_PARAM_NAMESPACE + constants.PARAM_REQUIRED,
         pluginParamNamespaceMustBeString: constants.THE + constants.PLUGIN_PARAM_NAMESPACE + constants.PARAM_MUST_BE_STRING,
-        pluginParamNamespaceMustHaveALengthOfAtLeastOne: constants.THE + constants.PLUGIN_PARAM_NAMESPACE + constants.PARAM_MUST_HAVE_LENGTH_OF_AT_LEAST_ONE // ,
-        // pluginParamMetricsRequired: constants.THE + constants.PLUGIN_PARAM_METRICS + constants.PARAM_REQUIRED,
-        // pluginParamMetricsMustBeArray: constants.THE + constants.PLUGIN_PARAM_METRICS + constants.PARAM_MUST_BE_ARRAY
+        pluginParamNamespaceMustHaveALengthOfAtLeastOne: constants.THE + constants.PLUGIN_PARAM_NAMESPACE + constants.PARAM_MUST_HAVE_LENGTH_OF_AT_LEAST_ONE,
+        pluginParamTestNameRequired: constants.THE + constants.PLUGIN_PARAM_TEST_NAME + constants.PARAM_REQUIRED,
+        pluginParamTestNameMustBeString: constants.THE + constants.PLUGIN_PARAM_TEST_NAME + constants.PARAM_MUST_BE_STRING,
+        pluginParamTestNameMustHaveALengthOfAtLeastOne: constants.THE + constants.PLUGIN_PARAM_TEST_NAME + constants.PARAM_MUST_HAVE_LENGTH_OF_AT_LEAST_ONE,
+        pluginParamEnvironmentMustBeString: constants.THE + constants.PLUGIN_PARAM_ENVIRONMENT + constants.PARAM_MUST_BE_STRING,
+        pluginParamEnvironmentHaveALengthOfAtLeastOne: constants.THE + constants.PLUGIN_PARAM_ENVIRONMENT + constants.PARAM_MUST_HAVE_LENGTH_OF_AT_LEAST_ONE,
     },
     impl = {
         validateConfig: function(scriptConfig) {
@@ -41,33 +45,146 @@ var aws = require('aws-sdk'),
             } else if (scriptConfig.plugins[constants.PLUGIN_NAME][constants.PLUGIN_PARAM_NAMESPACE].length === 0) {
                 throw new Error(messages.pluginParamNamespaceMustHaveALengthOfAtLeastOne);
             }
-            // // Validate METRICS
-            // if (!(messages.PLUGIN_PARAM_METRICS in pluginConfig)) {
-            //     throw new Error(messages.pluginParamMetricsRequired)
-            // } else if (!Array.isArray(pluginConfig[messages.PLUGIN_PARAM_METRICS])) {
-            //     throw new Error(messages.pluginParamMetricsMustBeArray);
-            // }
-            // for(var i = 0; pluginConfig[messages.PLUGIN_PARAM_METRICS].length; i++) {
-            //     validateMetric(pluginConfig[messages.PLUGIN_PARAM_METRICS][i]);
-            // }
-        },
-        buildCloudWatchParams: function(namespace, latency, latencies) {
-            var cloudWatchParams = {
-                    Namespace: namespace,
-                    MetricData: []
-                },
-                i,
-                lastLatency = Math.min(latency + 20, latencies.length);
-            for (i = latency; i < lastLatency; i++) {
-                cloudWatchParams.MetricData.push({
-                    MetricName: 'ResultLatency',
-                    Dimensions: [],
-                    Timestamp: (new Date(latencies[i][constants.TIMESTAMP])).toISOString(),
-                    Value: latencies[i][constants.LATENCY] / 1000000,
-                    Unit: 'Milliseconds'
-                });
+            // Validate TEST_NAME
+            if (!(constants.PLUGIN_PARAM_TEST_NAME in scriptConfig.plugins[constants.PLUGIN_NAME])) {
+                throw new Error(messages.pluginParamTestNameRequired);
+            } else if (!(typeof scriptConfig.plugins[constants.PLUGIN_NAME][constants.PLUGIN_PARAM_TEST_NAME] === 'string' || scriptConfig.plugins[constants.PLUGIN_NAME][constants.PLUGIN_PARAM_TEST_NAME] instanceof String)) {
+                throw new Error(messages.pluginParamTestNameMustBeString);
+            } else if (scriptConfig.plugins[constants.PLUGIN_NAME][constants.PLUGIN_PARAM_TEST_NAME].length === 0) {
+                throw new Error(messages.pluginParamTestNameMustHaveALengthOfAtLeastOne);
             }
-            return cloudWatchParams;
+            // Validate ENVIRONMENT
+            if ((constants.PLUGIN_PARAM_ENVIRONMENT in scriptConfig.plugins[constants.PLUGIN_NAME])) {
+                if (!(typeof scriptConfig.plugins[constants.PLUGIN_NAME][constants.PLUGIN_PARAM_ENVIRONMENT] === 'string' || scriptConfig.plugins[constants.PLUGIN_NAME][constants.PLUGIN_PARAM_ENVIRONMENT] instanceof String)) {
+                throw new Error(messages.pluginParamEnvironmentMustBeString);
+                } else if (scriptConfig.plugins[constants.PLUGIN_NAME][constants.PLUGIN_PARAM_ENVIRONMENT].length === 0) {
+                throw new Error(messages.pluginParamEnvironmentHaveALengthOfAtLeastOne);
+                }
+            }
+        },
+        buildReportResults: function (instance, testReport) {
+            const points = [];
+            const dimensions = [
+              {
+                Name: 'CATEGORY',
+                Value: 'performance'
+              },
+              ...instance.baseDimensions
+            ];
+        
+            if (testReport._entries) {
+              testReport.latencies = testReport._entries;
+            }
+        
+            if (testReport.latencies) {
+              for (let i = 0; i < testReport.latencies.length; i += 1) {
+                const sample = testReport.latencies[i];
+        
+                const timestamp = (new Date(sample[constants.TIMESTAMP])).toISOString();
+        
+                points.push({
+                  MetricName: 'Latency',
+                  Dimensions: [{
+                    Name: 'TYPE',
+                    Value: 'latency'
+                  }, ...dimensions],
+                  Timestamp: timestamp,
+                  Value: sample[constants.LATENCY] / 1000000,
+                  StorageResolution: 1,
+                  Unit: 'Milliseconds'
+                });
+        
+                points.push({
+                  MetricName: `StatusCode-${sample[constants.STATUS_CODE]}`,
+                  Dimensions: [{
+                    Name: 'TYPE',
+                    Value: 'statusCode'
+                  }, ...dimensions],
+                  Timestamp: timestamp,
+                  Unit: 'Count',
+                  StorageResolution: 1,
+                  Value: 1,
+                });
+              }
+            }
+        
+            return points;
+        },
+        buildReportErrors: function (instance, testReport) {
+            let errorCount = 0;
+            const dimensions = [
+              {
+                Name: 'CATEGORY',
+                Value: 'performance'
+              },
+              {
+                Name: 'TYPE',
+                Value: 'error'
+              },
+              ...instance.baseDimensions
+            ];
+        
+            if (testReport._errors) {
+              testReport.errors = testReport._errors;
+            }
+        
+            if (testReport.errors) {
+              Object.getOwnPropertyNames(testReport.errors).forEach((propertyName) => {
+                errorCount += testReport.errors[propertyName];
+              });
+            }
+        
+            return [{
+              MetricName: 'Error',
+              Dimensions: dimensions,
+              Timestamp: (new Date()).toISOString(),
+              Unit: 'Count',
+              StorageResolution: 1,
+              Value: errorCount,
+            }];
+        },
+        buildCountMetrics: function (instance, testReport) {
+            const timestamp = Math.max.apply(null, testReport._requestTimestamps);
+            const dimensions = [
+              {
+                Name: 'CATEGORY',
+                Value: 'flows'
+              },
+              {
+                Name: 'TYPE',
+                Value: 'count'
+              },
+              ...instance.baseDimensions
+            ];
+        
+            const counters = {
+              generatedScenarios: 0,
+              completedScenarios: 0,
+              completedRequests: 0
+            };
+        
+            if (testReport._generatedScenarios) {
+              const codeFamily = 'generatedScenarios';
+              counters[codeFamily] += testReport._generatedScenarios;
+            }
+            if (testReport._completedScenarios) {
+              const codeFamily = 'completedScenarios';
+              counters[codeFamily] += testReport._completedScenarios;
+            }
+            if (testReport._completedRequests) {
+              const codeFamily = 'completedRequests';
+              counters[codeFamily] += testReport._completedRequests;
+            }
+            const metrics = Object.entries(counters)
+              .map(([counter, amount]) => ({
+                MetricName: counter,
+                Dimensions: dimensions,
+                Timestamp: (new Date(timestamp)).toISOString(),
+                StorageResolution: 1,
+                Unit: 'Count',
+                Value: amount,
+              }));
+            return metrics;
         },
         CloudWatchPlugin: function(scriptConfig, eventEmitter) {
             var self = this,
@@ -77,25 +194,39 @@ var aws = require('aws-sdk'),
                     }
                 };
             self.config = JSON.parse(JSON.stringify(scriptConfig.plugins[constants.PLUGIN_NAME]));
+
+            self.baseDimensions = [{
+                Name: 'TEST_NAME',
+                Value: self.config[constants.PLUGIN_TEST_NAME]
+            }];
+          
+            if (self.config[constants.PLUGIN_ENVIRONMENT]) {
+                self.baseDimensions.push({
+                    Name: 'ENVIRONMENT',
+                    Value: self.config[constants.PLUGIN_ENVIRONMENT]
+                });
+            }
+            
             eventEmitter.on('stats', function (report) {
-                var latency = 0,
-                    latencies,
-                    cloudWatchParams;
-                if (report && report.aggregate && report.aggregate.latencies && Array.isArray(report.aggregate.latencies)) {
-                    latencies = report.aggregate.latencies;
-                } else if (report && report.latencies && Array.isArray(report.latencies)) {
-                    latencies = report.latencies;
-                } else if (report && report._entries && Array.isArray(report._entries)) {
-                    latencies = report._entries;
-                } else {
-                    latencies = [];
-                }
-                while (latency < latencies.length) {
-                    cloudWatchParams = impl.buildCloudWatchParams(self.config[constants.PLUGIN_PARAM_NAMESPACE], latency, latencies);
-                    cloudWatch.putMetricData(cloudWatchParams, reportError);
-                    latency += cloudWatchParams.MetricData.length;
-                }
-                console.log('Metrics reported to CloudWatch');
+                try {
+                    const reportMetrics = impl.buildReportResults(self, report);
+                    const countMetrics = impl.buildCountMetrics(self, report);
+                    const errorMetrics = impl.buildReportErrors(self, report);
+
+                    const metricData = [].concat(reportMetrics, countMetrics, errorMetrics);
+
+                    for (let i = 0; i < metricData.length; i += constants.MAX_METRIC_DATA_SIZE) {
+                        const data = metricData.slice(i, i + constants.MAX_METRIC_DATA_SIZE);
+                        const cloudWatchParams = {
+                        Namespace: self.config[constants.PLUGIN_PARAM_NAMESPACE],
+                        MetricData: data
+                        };
+                        cloudWatch.putMetricData(cloudWatchParams, reportError);
+                    }
+                    console.log('Metrics reported to CloudWatch');
+                } catch (err) {
+                reportError(err);
+              }
             });
         }
     },
@@ -113,13 +244,9 @@ var aws = require('aws-sdk'),
  *          "plugins": {
  *              "cloudwatch": {
  *                  "namespace": "[INSERT_NAMESPACE]",
- // *                  "metrics": [
- // *                      {
- // *                          "name": "[METRIC_NAME]",
- // *                          "dimensions": [...],
- // *
- // *                      }
- // *                  ]
+ *                  "testName": "[INSERT_TEST_NAME]"
+ // *                  Optional:
+ // *               "environment": "[INSERT_ENVIRONMENT]"     
  *              }
  *          }
  *      }


### PR DESCRIPTION
Added a required param `testName` and a optional one `environment` so we can share a namespace by multiple tests filtering it with those two dimensions.
Changed the store resolution to 1 second so when aggregating using the 10 seconds option in CW it matches what we have in InfluxDB
Added statuses and the counters metrics for generatedScenarios, completedScenarios and completedRequests. Adjusted the latencies metrics and now it matches the InfluxDB plugin:

![image](https://user-images.githubusercontent.com/8834774/100376025-67719000-2fd4-11eb-81bc-5aadd2a92053.png)


fixes https://github.com/Nordstrom/artillery-plugin-cloudwatch/issues/11